### PR TITLE
Update troubleshooting docs for Lambda timeout

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,7 +155,7 @@ log_content[:2000]  # Increase limit in code
 **Symptoms:** Function times out after 300 seconds
 
 **Solutions:**
-1. Increase timeout in SAM template
+1. Increase the Lambda timeout in your Terraform configuration (or other IaC template)
 2. Add parallel processing:
    ```python
    import concurrent.futures


### PR DESCRIPTION
## Summary
- update Lambda timeout note in troubleshooting guide

## Testing
- `python -m pytest tests/ -q` *(fails: ModuleNotFoundError for `google.ai` and missing `get_redshift_recent_errors`)*

------
https://chatgpt.com/codex/tasks/task_e_6882a6c26de4832b98ac5af4bffbf550