### PR TITLE
Remove unused dateutil dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,3 @@ urllib3==2.1.0
 google-generativeai==0.3.2
 
 # Utilities
-python-dateutil==2.8.2
-pytz==2023.3


### PR DESCRIPTION
## Summary
- drop `python-dateutil` and `pytz` from primary requirements
- run package install and tests

## Testing
- `pip install -r requirements.txt --use-deprecated=legacy-resolver`
- `pytest -q` *(fails: cannot import name 'get_redshift_recent_errors')*

------
https://chatgpt.com/codex/tasks/task_e_6882a6c40a20832bb8ff5fd9d4c24b12