### PR TITLE
Update env variable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The agent requires the following environment variables (managed through Terrafor
 - `REDSHIFT_CLUSTER_ID`: Your Redshift cluster identifier
 - `REDSHIFT_DATABASE`: Database name for audit logs
 - `MWAA_ENVIRONMENT_NAME`: MWAA environment name
+- `DIAGNOSTIC_LAMBDA_NAME`: Name of the diagnostic Lambda (set by Terraform)
 
 ## 🧪 Testing
 


### PR DESCRIPTION
## Summary
- document `DIAGNOSTIC_LAMBDA_NAME` in the env var list in README

## Testing
- `AWS_DEFAULT_REGION=us-east-1 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_6882a6d73e58832bbcdcae3626e17452