### PR TITLE
Implement llm call and add unit tests

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+from unittest.mock import Mock, patch
+
+from src.orchestrator import DiagnosticOrchestrator
+
+
+def test_call_llm_success():
+    orchestrator = DiagnosticOrchestrator()
+    with patch('google.generativeai') as mock_genai:
+        mock_model = Mock()
+        mock_response = Mock(text='LLM result')
+        mock_model.generate_content.return_value = mock_response
+        mock_genai.GenerativeModel.return_value = mock_model
+
+        result = asyncio.run(orchestrator._call_llm('test prompt'))
+
+        assert result == 'LLM result'
+        mock_genai.configure.assert_called_once()
+        mock_genai.GenerativeModel.assert_called_once_with('gemini-pro')
+        mock_model.generate_content.assert_called_once()
+
+
+def test_call_llm_failure():
+    orchestrator = DiagnosticOrchestrator()
+    with patch('google.generativeai') as mock_genai:
+        mock_genai.GenerativeModel.side_effect = Exception('boom')
+        with pytest.raises(Exception):
+            asyncio.run(orchestrator._call_llm('prompt'))


### PR DESCRIPTION
## Summary
- switch orchestrator to use prompt_engine
- implement actual Gemini call in `_call_llm`
- add helper functions for secrets, MWAA, Redshift, Slack in tools
- lazily create boto3 clients to ease testing
- add `test_orchestrator` covering success and failure of `_call_llm`

## Testing
- `pytest -q tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_6882a6d9b4a4832baf3a6f1f8060ba6f